### PR TITLE
Added auto cache clean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,12 @@ request: function(resource, options) {
 }
 ```
 
+### autoCleanCache
+
+When `true`, all cache for resource is automatically removed when `PUT`, `POST` or `DELETE` request is sent.
+By default: `false`.
+
+
 *Note: Want more options ? Open up a New Feature Issue above.*
 
 Conceptual Overview

--- a/src/jquery.rest.coffee
+++ b/src/jquery.rest.coffee
@@ -36,6 +36,7 @@ defaultOpts =
   url: ''
   cache: 0
   request: (resource, options) -> $.ajax(options)
+  autoCleanCache: false,
   cachableMethods: ['GET']
   methodOverride: false
   stringifyData: false
@@ -240,6 +241,10 @@ class Resource
       key = @root.cache.key ajaxOpts
       req = @root.cache.get key
       return req if req
+
+    if @opts.cache && @opts.autoCleanCache && $.inArray(method, @opts.cachableMethods) is -1
+      escapedUrl = url.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1")
+      @root.cache.clear(new RegExp(escapedUrl))
 
     req = @opts.request @parent, ajaxOpts
 


### PR DESCRIPTION
When resource is updated or deleted cache should be removed. Added option `autoCleanCache` which by default is `false`.
